### PR TITLE
Search for bib files in both current and parent documents

### DIFF
--- a/R/insert_citation.R
+++ b/R/insert_citation.R
@@ -66,7 +66,8 @@ insert_citation <- function(bib_file = getOption("citr.bibliography_path"), use_
     }
 
   ## Search parent documents
-  } else if(any(parents)) {
+  }
+  if(any(parents)) {
     if(sum(parents) > 1) stop("More than one parent document found. See getOption('citr.parent_documents').")
 
     parent_document <- readLines(parents_path[parents])
@@ -75,7 +76,7 @@ insert_citation <- function(bib_file = getOption("citr.bibliography_path"), use_
     if(length(parent_yaml_delimiters) >= 2 &&
        (parent_yaml_delimiters[2] - parent_yaml_delimiters[1] > 1) &&
        grepl("^---\\s*$", parent_document[parent_yaml_delimiters[1]])) {
-        yaml_bib_file <- yaml::yaml.load(paste(parent_document[(parent_yaml_delimiters[1] + 1):(parent_yaml_delimiters[2] - 1)], collapse = "\n"))$bibliography
+        yaml_bib_file <- c(yaml_bib_file, yaml::yaml.load(paste(parent_document[(parent_yaml_delimiters[1] + 1):(parent_yaml_delimiters[2] - 1)], collapse = "\n"))$bibliography)
     }
   }
 


### PR DESCRIPTION
The current document may have content that looks like YAML but not really YAML, e.g. a literal YAML example

``````
```yaml

---
title: "A Nice Book"
knit: bookdown::render_book
output:
  bookdown::gitbook: default

---
```
``````

Currently it will be recognized as YAML but it is not. I'd suggest continue searching the parent documents for bibliography in this case.
