### PR TITLE
VSCode compatibility: check for rstudioapi functions using hasFun rather than version num

### DIFF
--- a/R/insert_citation.R
+++ b/R/insert_citation.R
@@ -49,12 +49,14 @@ insert_citation <- function(
     warning("Argument 'use_betterbiblatex' is deprecated; set the global option 'citr.betterbiblatex_format' instead.", call. = FALSE)
   }
 
-  if(rstudioapi::isAvailable("0.99.1111")) {
+  context <- NULL
+  if(rstudioapi::hasFun("getSourceEditorContext")) {
     context <- tryCatch(rstudioapi::getSourceEditorContext(), error = function(e) NULL)
   }
-  if((exists("context") && is.null(context)) || rstudioapi::isAvailable("0.99.796")) {
+  else if(rstudioapi::hasFun("getActiveDocumentContext")) {
     context <- rstudioapi::getActiveDocumentContext()
-  } else stop(
+  }
+  if (is.null(context)) stop(
     "The use of this addin requires RStudio 0.99.796 or newer (your version is "
     , rstudioapi::versionInfo()$version
     , ")."


### PR DESCRIPTION
Hi,

Very soon VSCode will have [support for RStudio addins](https://github.com/Ikuyadeu/vscode-R/pull/408). `citr` is quite a popular addin so I thought I would test compatibility.

Currently the way `citr` checks for specific RStudio versions is not compatible with VSCode `{rstudioapi}` emulation, since VSCode will probably never lie and claim to be a specific RStudio version. However if `citr` checks for API functions it is dependent on using `rstudioapi::hasFun`, it would be fully compatible with VSCode. I have made this change in this PR and tested it locally and it verified `citr` works with VSCode and RStudio using this verification method.

Thanks for the great addin. I would love to be able to include it on the list of verified supported addins in VSCode.